### PR TITLE
fix: 修复帖子楼主高亮偶发失效的问题

### DIFF
--- a/app/src/main/assets/pure.js
+++ b/app/src/main/assets/pure.js
@@ -3,14 +3,46 @@
     'use strict';
 
     const author = `[AUTHOR]`;
-    const eleUsers = document.querySelectorAll('a.uname');
 
+  function highlight() {
+    const eleUsers = document.querySelectorAll('a.uname');
     for (const eleUser of eleUsers) {
-        const userName = eleUser.textContent.trim();
-        if (userName == author) {
-            eleUser.style.color = "#00c853"
+      const userName = eleUser.textContent.trim();
+      if (userName == author) {
+        eleUser.style.color = "#00c853"
+        // 找到楼主后降频兜底 (文档重建 / 加载更多时仍能高亮)
+        if (!window.__purenga_slow) {
+          window.__purenga_slow = 1;
+          clearInterval(window.__purenga_hl);
+          window.__purenga_hl = setInterval(highlight, 2000);
         }
+      }
     }
+  }
+
+  highlight();
+
+  // DOM 变化时立即高亮; NGA 渲染时可能整体重建 document, 旧目标的 observer 会失效,
+  // 此时重新注册; 轮询作为兜底
+  try {
+    if (
+      !window.__purenga_mo ||
+      !window.__purenga_mo_t ||
+      !window.__purenga_mo_t.isConnected
+    ) {
+      const target = document.documentElement || document.body;
+      const mo = new MutationObserver(highlight);
+      mo.observe(target, { childList: true, subtree: true });
+      window.__purenga_mo = mo;
+      window.__purenga_mo_t = target;
+    }
+  } catch (err) {
+    // 忽略
+  }
+
+  if (!window.__purenga_hl) {
+    window.__purenga_hl = setInterval(highlight, 100);
+  }
 
     try{
         [CUSTOM_HS]

--- a/app/src/main/kotlin/com/chrxw/purenga/Constant.kt
+++ b/app/src/main/kotlin/com/chrxw/purenga/Constant.kt
@@ -73,5 +73,5 @@ object Constant {
     const val STR_PURENGA_SETTING = "PureNGA 设置"
     const val STR_COPYRIGHT_WARNING = "本软件免费开源, 如果在任何渠道付费取得本软件, 请申请退款"
 
-    const val JS_HIGHLIGHT = "(()=>{'use strict';const author=`[AUTHOR]`;const eleUsers=document.querySelectorAll('a.uname');for(const eleUser of eleUsers){const userName=eleUser.textContent.trim();if(userName==author){eleUser.style.color=\"#00c853\"}}try{[CUSTOM_HS]}catch(err){alert(\"自定义脚本错误: \"+err)}})();"
+    const val JS_HIGHLIGHT = "(()=>{'use strict';const author=`[AUTHOR]`;const hl=()=>{const eleUsers=document.querySelectorAll('a.uname');for(const eleUser of eleUsers){const userName=eleUser.textContent.trim();if(userName==author){eleUser.style.color=\"#00c853\";if(!window.__purenga_slow){window.__purenga_slow=1;clearInterval(window.__purenga_hl);window.__purenga_hl=setInterval(hl,2000)}}}};hl();try{if(!window.__purenga_mo||!window.__purenga_mo_t||!window.__purenga_mo_t.isConnected){const t=document.documentElement||document.body;const mo=new MutationObserver(hl);mo.observe(t,{childList:true,subtree:true});window.__purenga_mo=mo;window.__purenga_mo_t=t}}catch(err){}if(!window.__purenga_hl)window.__purenga_hl=setInterval(hl,100);try{[CUSTOM_HS]}catch(err){alert(\"自定义脚本错误: \"+err)}})();"
 }

--- a/app/src/main/kotlin/com/chrxw/purenga/hook/ArticleDetailHook.kt
+++ b/app/src/main/kotlin/com/chrxw/purenga/hook/ArticleDetailHook.kt
@@ -75,6 +75,23 @@ class ArticleDetailHook : IHook {
             var webView: WebView? = null
             var authorName: String? = null
 
+            val injectHighlight = {
+                val author = authorName
+                val wv = webView
+                if (wv == null || author.isNullOrEmpty()) {
+                    AndroidLogger.w("webView is null")
+                } else {
+                    AndroidLogger.w("高亮楼主: $author")
+                    val customJs = Helper.getSpStr(Constant.CUSTOM_POST_JS, null) ?: ""
+                    val js = Constant.JS_HIGHLIGHT.replace("[AUTHOR]", author)
+                        .replace("[CUSTOM_HS]", customJs)
+
+                    wv.loadUrl("javascript:$js")
+                    AndroidLogger.i("loaded JS")
+                    AndroidLogger.i(js)
+                }
+            }
+
             findFirstMethodByName(clsArticleDetailFragment, "finishLoad")?.createHook {
                 before {
                     it.log()
@@ -105,6 +122,8 @@ class ArticleDetailHook : IHook {
 
                     webView = fidWebView.get(it.thisObject) as WebView
                     authorName = fidThreadAuthor.get(it.thisObject) as String
+
+                    injectHighlight()
                 }
             }
 
@@ -122,22 +141,7 @@ class ArticleDetailHook : IHook {
                     after {
                         it.forceLog()
 
-                        val author = authorName
-                        val wv = webView
-                        if (wv == null || author.isNullOrEmpty()) {
-                            AndroidLogger.w("webView is null")
-                            return@after
-                        }
-
-                        AndroidLogger.w("高亮楼主: $author")
-                        val customJs = Helper.getSpStr(Constant.CUSTOM_POST_JS, null) ?: ""
-                        val js = Constant.JS_HIGHLIGHT.replace("[AUTHOR]", author)
-                            .replace("[CUSTOM_HS]", customJs)
-
-                        wv.loadUrl("javascript:$js")
-                        AndroidLogger.i("loaded JS")
-                        AndroidLogger.i(js)
-
+                        injectHighlight()
                     }
                 }
             } ?: AndroidLogger.w("onPageFinished hook 失败")


### PR DESCRIPTION

## 问题描述

开启「帖子楼主高亮」后，**首次进入帖子时楼主 ID 有时不会被染成绿色**，刷新或退出重进后恢复正常。出现概率随机，主要取决于帖子页面的渲染时序。

## 复现步骤

1. 设置中开启「帖子楼主高亮」
2. 进入一个此前未打开过的帖子（数据无缓存）
3. 楼主 ID 未变绿；下拉刷新或退出重进后变绿

## 根因分析

### 原实现流程（v3.4.0）

1. hook `ArticleDetailFragment#finishLoad`，记录 `mWebView` 与 `mThreadAuthor`（楼主名）；
2. hook `ArticleDetailFragment$q#onPageFinished`，在页面加载完成回调中通过 `WebView.loadUrl("javascript:...")` 注入高亮脚本；
3. 脚本逻辑：遍历页面上所有 `a.uname` 元素，元素文本与楼主名一致则染成绿色。

### 问题所在

- 高亮脚本为**一次性执行**：注入时刻若帖子楼层内容尚未渲染完成（NGA 客户端为异步渲染），`document.querySelectorAll('a.uname')` 返回空集合，脚本空转结束；
- 楼层内容渲染完成时**没有任何回调**会再次触发注入，错过时机后无任何重试；
- NGA 渲染过程中还会**整体重建 document**，即便已完成染色的元素也会被清空；
- 此外原实现只依赖 `onPageFinished` 注入，当日志显示它先于 `finishLoad` 触发时（此时楼主名尚未记录），注入被直接跳过，若之后不再触发 `onPageFinished` 则同样永久错过。

### 日志证据

真机复现（小米 13 / NGA 9.9.68 / PureNGA 3.4.0，`logcat -s PureNGA:V`）抓到的完整时序：

**失败：首次进入帖子（楼主「天空中的大魔导师」）**

```log
11:28:12.548  onPageFinished                          # 页面回调触发, 但楼主名尚未记录 → 跳过注入
11:28:12.645  finishLoad                              # 帖子数据加载完成, 记录楼主名/ID
11:28:12.646  finishLoad
11:28:12.813  onPageFinished → 注入 #1 (loaded JS)    ┐
11:28:12.890  onPageFinished → 注入 #2 (loaded JS)    ├ 3 次注入均已执行,
11:28:13.127  onPageFinished → 注入 #3 (loaded JS)    ┘ 但楼层内容尚未渲染 → 无一生效
（此时用户确认楼主未变绿，等待数秒后刷新）
```

**成功：下拉刷新同一帖子**

```log
11:28:18.928  finishLoad                              # 刷新触发, 数据已缓存
11:28:18.930  finishLoad
11:28:19.147  onPageFinished → 注入 #1 (loaded JS)    # 注入时楼层元素已就绪 → 高亮成功
11:28:24.758  onDetach                                # 退出帖子
```

**结论**：

- 失败场景中脚本确实被注入了 **3 次**（每条 `loaded JS` 对应一次 `loadUrl("javascript:...")` 调用），所以问题不是"没有注入"；
- 失败与成功的差异不是注入次数（3 次 vs 1 次），而是**注入那一刻楼层 DOM 是否已渲染完成**：失败时内容还在渲染中，成功时（刷新、数据缓存）内容已就绪；
- 由于脚本一次性执行且无重试，注入早于渲染即永久失效。

### 补充验证（WebView CDP 调试）

通过 `webview_devtools_remote` 远程调试检查失败页面的内部状态：

- 脚本执行标记已写入 `window`（证明注入确实执行过）；
- `document.querySelectorAll('a.uname').length === 20`（元素最终已渲染存在于 DOM）；
- 但所有元素均无高亮样式（`coloredUnames` 为空，且无任何静态标识可区分楼主）。

即在"脚本执行 → 内容渲染完成"之间缺少任何重试机会，与日志时序结论一致。

另外通过 CDP 模拟 `document.open/write/close` 重建文档（与 NGA 行为一致：window 属性在重建后保留），验证了各方案的覆盖能力：

```
window 属性保留（window.__x === 1）        # 证实是 document 重建而非页面导航
window 级 load / DOMContentLoaded 监听     # 均不会再次触发
旧 MutationObserver                        # 随旧 documentElement 失效
```

即 document 重建没有任何可监听事件，这正是注入脚本需要常驻轮询兜底的原因。

## 修复方案

### 1. 注入脚本改为「事件驱动 + 轮询兜底」（`Constant.kt`、`assets/pure.js`）

- 使用 `MutationObserver` 监听 DOM 变化，楼主元素一出现**立即染色**（零延迟，事件驱动）；
- 使用 `setInterval` 轮询兜底（初始 100ms，**找到楼主后自动降频至 2s**），解决 NGA 重建 document 后 observer 失效的问题；
- observer 绑定的根节点断开（document 被重建）时自动重新注册；
- 防重复：observer 与定时器均只注册一次，避免同一页面多次注入时重复累积。

### 2. 补充注入时机（`ArticleDetailHook.kt`）

- 抽取 `injectHighlight()`，在 `finishLoad` 之后也补一次注入；
- 原实现仅依赖 `onPageFinished`，当其先于 `finishLoad` 触发时会错过注入窗口且不重试（此时 `mThreadAuthor` 尚未记录）。

## 验证情况

- **真机验证**（小米 13 / NGA 9.9.68 / PureNGA 3.4.0）：测试多个此前必现的帖子（含中文、英数字 ID），首次进入均正常高亮，无需刷新；
- **logcat 验证**：各帖子注入正常、无异常输出；
- **Node 模拟测试**覆盖以下场景均通过：
  - 注入时 DOM 未就绪 → 内容渲染后自动补染色；
  - document 重建 → observer 自动重注册 + 轮询兜底染色；
  - 同一页面多次注入 → observer/定时器不重复注册;
  - 后续新增楼层（加载更多）→ observer 即刻响应。

## 影响与风险

- 仅影响开启「帖子楼主高亮」的用户，其他功能不受影响；
- 性能开销：轮询仅在未命中阶段以 100ms 运行（通常持续 1~2 秒），命中后降频为 2s 一次；单次查询开销约 0.1ms，稳定后每分钟约 30 次查询，对性能无可感知影响；
- 无新增依赖，无 API/配置变更。

## Commit Message

```
fix: 修复帖子楼主高亮偶发失效的问题

- 注入脚本改为 MutationObserver 事件驱动 + 轮询兜底，解决页面渲染滞后与 document 重建导致高亮丢失的问题
- finishLoad 后补充注入，避免 onPageFinished 先于 finishLoad 触发时错过注入时机
```
